### PR TITLE
feat: Pin actions to hashes

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0 # Enable checking Git history
 
@@ -18,7 +18,7 @@ jobs:
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_ENV"
 
       - name: Build and test with Node.js ${{ env.NODE_VERSION }}
-        uses: linz/action-typescript@v3
+        uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://npm.pkg.github.com
@@ -29,7 +29,7 @@ jobs:
         run: echo "PYTHON_VERSION=$(cat .python-version)" >> "$GITHUB_ENV"
 
       - name: Setup Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v4.7.1
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -56,13 +56,13 @@ jobs:
       packages: read
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Get Node.js version
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_ENV"
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3.8.1
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://npm.pkg.github.com/
@@ -74,7 +74,7 @@ jobs:
         run: npm ci --omit=dev
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4.0.1
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           aws-region: ap-southeast-2
           role-to-assume: ${{ github.ref == 'refs/heads/master' && 'arn:aws:iam::434775598764:role/ContinuousIntegration-GitHubActionsRole4F1BBA26-U1I7SY11QA7D' || 'arn:aws:iam::623931144233:role/ContinuousIntegration-GitHubActionsRole4F1BBA26-WDE0O3ZN93A6' }}


### PR DESCRIPTION
Done with pin-github-action <https://github.com/mheap/pin-github-action> 1.8.0 using `npx pin-github-action .github/workflows/*.yml`.

Dependabot should support updating in the same fashion <https://github.com/dependabot/dependabot-core/issues/8277#issuecomment-1782819752>.

Had to `export GH_ADMIN_TOKEN=github_pat_…` using a fine-grained personal access tokens with no extra access to work around rate limiting *and* to be able to work in private repos
<https://github.com/mheap/pin-github-action/issues/73>.